### PR TITLE
Update install: binary only

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -8,7 +8,7 @@ Expand-Archive nvm.zip -DestinationPath "$NVM_HOME"
 New-Item -Path "$NVM_HOME\settings.txt" -ItemType File 
 nvm.exe root $NVM_HOME
 nvm.exe node_mirror $args[1]
-nvm.exe install $args[0]
+nvm.exe install $args[0] -b
 nvm.exe use $args[0]
 echo "SETUP_NODE_NVM_NVM: $NVM_HOME"
 echo "SETUP_NODE_NVM_NODE: $NVM_HOME\nodejs\node.exe"

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --
 popd
 chmod +x "$NVM_DIR/nvm.sh"
 . "$NVM_DIR/nvm.sh" --no-use
-nvm install "$1"
+nvm install "$1" -b
 echo "SETUP_NODE_NVM_NVM: $NVM_DIR/nvm.sh"
 echo "SETUP_NODE_NVM_NODE: $(which node)"
 echo "SETUP_NODE_NVM_NPM: $(which npm)"


### PR DESCRIPTION
Only install the binary, do not try to compile from source, it takes up too many Github Action minutes. Better to just fail and let the user retry the job.